### PR TITLE
Allow glk_window_get_arrangement to take NULL arguments

### DIFF
--- a/GlkDll/GlkWindow.cpp
+++ b/GlkDll/GlkWindow.cpp
@@ -1121,9 +1121,12 @@ void CWinGlkWndPair::SetArrangement(glui32 Method, glui32 Size, CWinGlkWnd* pKey
 
 void CWinGlkWndPair::GetArrangement(glui32* MethodPtr, glui32* SizePtr, CWinGlkWnd** pKeyPtr)
 {
-  *MethodPtr = m_Method;
-  *SizePtr = m_Size;
-  *pKeyPtr = m_pKey;
+  if (MethodPtr)
+    *MethodPtr = m_Method;
+  if (SizePtr)
+    *SizePtr = m_Size;
+  if (pKeyPtr)
+    *pKeyPtr = m_pKey;
 }
 
 


### PR DESCRIPTION
I ran into what seems to be a bug in Windows-Glk.  According to Section 1.9 of the Glk Specification, "Other API Conventions",

> Some functions have pointer arguments, acting as "variable" or "reference" arguments; the function’s intent is to return some value in the space pointed to by the argument. Unless the function says otherwise, it is legal to pass NULL to indicate that you do not care about that value.

The documentation for `glk_window_get_arrangement` does not say otherwise, but Windows-Glk still assumes that all three pointers are non-null.  This commit removes that assumption.
